### PR TITLE
Add support for crlf line break

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = (source, line, options) => {
 		throw new TypeError('Line number must start from `1`.');
 	}
 
-	source = tabsToSpaces(source).split('\n');
+	source = tabsToSpaces(source).split(/\r?\n/);
 
 	if (line > source.length) {
 		return null;


### PR DESCRIPTION
Fixes #1 

Update split regex to support `\r\n` line breaks.
Since `npm v5.x` generates the package-lock.json and this project has no lock file, should I generate one?